### PR TITLE
Download EAP xml and saving to DB

### DIFF
--- a/android/app/src/main/java/app/eduroam/geteduroam/AndroidApp.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/AndroidApp.kt
@@ -20,8 +20,8 @@ class AndroidApp : Application() {
         initKoin(module {
             single<Context> { this@AndroidApp }
             viewModel {
-                SelectInstitutionViewModel(get(),
-                    get { parametersOf("SelectInstitutionViewModel") })
+                SelectInstitutionViewModel(institutionRepository = get(),
+                    log = get { parametersOf("SelectInstitutionViewModel") })
             }
             viewModel { SelectProfileViewModel(get { parametersOf("SelectProfileViewModel") }) }
             single<AppInfo> { AndroidAppInfo }

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ buildscript {
         classpath Libs.firebaseDistributionPlugin
         classpath Libs.Kotlin.gradlePlugin
         classpath Libs.Kotlin.serialization
+        classpath Libs.SqlDelight.gradlePlugin
     }
 }
 

--- a/buildSrc/src/main/java/app/eduroam/shared/Dependencies.kt
+++ b/buildSrc/src/main/java/app/eduroam/shared/Dependencies.kt
@@ -4,7 +4,8 @@ object Libs {
     const val androidGradlePlugin = "com.android.tools.build:gradle:7.1.3"
     const val googleService = "com.google.gms:google-services:4.3.10"
     const val crashlyticsPlugin = "com.google.firebase:firebase-crashlytics-gradle:2.8.1"
-    const val firebaseDistributionPlugin = "com.google.firebase:firebase-appdistribution-gradle:3.0.1"
+    const val firebaseDistributionPlugin =
+        "com.google.firebase:firebase-appdistribution-gradle:3.0.1"
     const val timberLog = "com.jakewharton.timber:timber:5.0.1"
     const val desugaring = "com.android.tools:desugar_jdk_libs:1.1.5"
 
@@ -24,7 +25,8 @@ object Libs {
             const val runtime = "androidx.compose.runtime:runtime:$version"
             const val runtimeLivedata = "androidx.compose.runtime:runtime-livedata:$version"
             const val material = "androidx.compose.material:material:$version"
-            const val materialIconsExt = "androidx.compose.material:material-icons-extended:$version"
+            const val materialIconsExt =
+                "androidx.compose.material:material-icons-extended:$version"
             const val foundation = "androidx.compose.foundation:foundation:$version"
             const val layout = "androidx.compose.foundation:foundation-layout:$version"
             const val tooling = "androidx.compose.ui:ui-tooling:$version"
@@ -77,6 +79,11 @@ object Libs {
     object Coil {
         private const val version = "1.3.2"
         const val coilCompose = "io.coil-kt:coil-compose:$version"
+    }
+
+    object DateTime {
+        private const val version = "0.4.0"
+        const val datetime = "org.jetbrains.kotlinx:kotlinx-datetime:$version"
     }
 
     object Firebase {
@@ -142,6 +149,13 @@ object Libs {
     object Material {
         private const val version = "1.6.1"
         const val design = "com.google.android.material:material:$version"
+    }
+
+    object SqlDelight {
+        const val version = "1.5.3"
+        const val androidDriver = "com.squareup.sqldelight:android-driver:$version"
+        const val iOsDriver = "com.squareup.sqldelight:native-driver:$version"
+        const val gradlePlugin = "com.squareup.sqldelight:gradle-plugin:$version"
     }
 
     object Touchlab {

--- a/shared/core/build.gradle
+++ b/shared/core/build.gradle
@@ -3,7 +3,15 @@ import app.eduroam.shared.Libs
 apply plugin: 'kotlin-multiplatform'
 apply plugin: 'kotlin-native-cocoapods'
 apply plugin: 'kotlinx-serialization'
+apply plugin: 'com.squareup.sqldelight'
 apply from: 'android.gradle'
+
+sqldelight {
+    EduRoamDatabase {
+        packageName = "app.eduroam.shared.storage"
+        sourceFolders = ["sqldelight"]
+    }
+}
 
 group = "app.eduroam.shared"
 version = "1.0"
@@ -56,14 +64,23 @@ kotlin {
                 implementation Libs.Ktor.clientCore
                 implementation Libs.Ktor.clientSerialization
                 implementation Libs.Ktor.contentNegotiation
+                implementation Libs.DateTime.datetime
                 api Libs.Ktor.logging
                 implementation Libs.Touchlab.stately
                 api Libs.Touchlab.kermit
             }
         }
+
+        androidMain {
+            dependencies {
+                implementation Libs.SqlDelight.androidDriver
+            }
+        }
+
         iosMain {
             dependencies {
                 implementation Libs.Ktor.clientiOS
+                implementation Libs.SqlDelight.iOsDriver
             }
         }
     }

--- a/shared/core/src/androidMain/kotlin/app/eduroam/shared/KoinAndroid.kt
+++ b/shared/core/src/androidMain/kotlin/app/eduroam/shared/KoinAndroid.kt
@@ -1,5 +1,6 @@
 package app.eduroam.shared
 
+import app.eduroam.shared.storage.DriverFactory
 import io.ktor.client.engine.okhttp.*
 import org.koin.core.module.Module
 import org.koin.dsl.module
@@ -8,5 +9,8 @@ import org.koin.dsl.module
 actual val platformModule: Module = module {
     single {
         OkHttp.create()
+    }
+    single {
+        DriverFactory(get())
     }
 }

--- a/shared/core/src/androidMain/kotlin/app/eduroam/shared/storage/DriverFactory.kt
+++ b/shared/core/src/androidMain/kotlin/app/eduroam/shared/storage/DriverFactory.kt
@@ -1,0 +1,10 @@
+package app.eduroam.shared.storage
+
+import android.content.Context
+import com.squareup.sqldelight.android.AndroidSqliteDriver
+import com.squareup.sqldelight.db.SqlDriver
+
+actual class DriverFactory(private val context: Context) {
+    actual fun createDriver(): SqlDriver =
+        AndroidSqliteDriver(EduRoamDatabase.Schema, context, "eduroam.db")
+}

--- a/shared/core/src/commonMain/kotlin/app/eduroam/shared/Koin.kt
+++ b/shared/core/src/commonMain/kotlin/app/eduroam/shared/Koin.kt
@@ -50,13 +50,15 @@ private val coreModule = module {
     // uses you *may* want to have a more robust configuration from the native platform. In KaMP Kit,
     // that would likely go into platformModule expect/actual.
     // See https://github.com/touchlab/Kermit
-    val baseLogger = Logger(config = StaticConfig(logWriterList = listOf(platformLogWriter())), "KampKit")
+    val baseLogger =
+        Logger(config = StaticConfig(logWriterList = listOf(platformLogWriter())), "eduroam")
     factory { (tag: String?) -> if (tag != null) baseLogger.withTag(tag) else baseLogger }
 
     single {
         InstitutionsRepository(
-            get(),
-            getWith("SelectInstitutionRepository"),
+            institutionApi = get(),
+            driverFactory = get(),
+            log = getWith("SelectInstitutionRepository"),
         )
     }
 }

--- a/shared/core/src/commonMain/kotlin/app/eduroam/shared/ktor/InstitutionApi.kt
+++ b/shared/core/src/commonMain/kotlin/app/eduroam/shared/ktor/InstitutionApi.kt
@@ -4,4 +4,5 @@ import app.eduroam.shared.response.InstitutionResult
 
 interface InstitutionApi {
     suspend fun getJsonFromApi(): InstitutionResult
+    suspend fun downloadEapFile(eapconfigEndpoint: String): ByteArray
 }

--- a/shared/core/src/commonMain/kotlin/app/eduroam/shared/ktor/InstitutionApiImpl.kt
+++ b/shared/core/src/commonMain/kotlin/app/eduroam/shared/ktor/InstitutionApiImpl.kt
@@ -57,6 +57,19 @@ class InstitutionApiImpl(private val log: KermitLogger, engine: HttpClientEngine
         }.body()
     }
 
+    suspend fun test(downloadUrl: String) {
+    }
+
+    override suspend fun downloadEapFile(eapConfigEndpoint: String): ByteArray {
+        log.d("Download EAP file")
+        val response = client.get(eapConfigEndpoint) {
+            onDownload { bytesSentTotal, contentLength ->
+                log.d("Received $bytesSentTotal bytes from $contentLength")
+            }
+        }
+        return response.body()
+    }
+
     private fun HttpRequestBuilder.institutions(path: String) {
         url {
             takeFrom("https://discovery.eduroam.app/")

--- a/shared/core/src/commonMain/kotlin/app/eduroam/shared/storage/DriverFactory.kt
+++ b/shared/core/src/commonMain/kotlin/app/eduroam/shared/storage/DriverFactory.kt
@@ -1,0 +1,14 @@
+package app.eduroam.shared.storage
+
+import com.squareup.sqldelight.db.SqlDriver
+
+expect class DriverFactory {
+    fun createDriver(): SqlDriver
+}
+
+fun createDatabase(driverFactory: DriverFactory): EduRoamDatabase {
+    val driver = driverFactory.createDriver()
+    val database = EduRoamDatabase(driver)
+    // Do more work with the database (see below).
+    return database
+}

--- a/shared/core/src/commonMain/sqldelight/app/eduroam/shared/storage/eduroamdb.sq
+++ b/shared/core/src/commonMain/sqldelight/app/eduroam/shared/storage/eduroamdb.sq
@@ -1,0 +1,17 @@
+CREATE TABLE eapFiles (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  categoryId TEXT NOT NULL,
+  profileId TEXT NOT NULL,
+  eapFile BLOB NOT NULL,
+  lastDownloadTimestamp INTEGER NOT NULL
+);
+
+CREATE INDEX eapFiles_profileId ON eapFiles(profileId);
+CREATE INDEX eapFiles_categoryId ON eapFiles(categoryId);
+
+saveEapFile:
+INSERT OR REPLACE INTO eapFiles(categoryId, profileId, eapFile, lastDownloadTimestamp)
+VALUES (?,?,?,?);
+
+getEapFile:
+SELECT eapFile FROM eapFiles WHERE categoryId=? AND profileId=?;

--- a/shared/core/src/iosMain/kotlin/app/eduroam/shared/KoinIOS.kt
+++ b/shared/core/src/iosMain/kotlin/app/eduroam/shared/KoinIOS.kt
@@ -1,17 +1,14 @@
 package app.eduroam.shared
 
 import app.eduroam.shared.models.SelectInstitutionCallbackViewModel
-import org.koin.core.module.Module
-import org.koin.dsl.module
-
+import app.eduroam.shared.storage.DriverFactory
 import co.touchlab.kermit.Logger
-import io.ktor.client.engine.darwin.Darwin
+import io.ktor.client.engine.darwin.*
 import org.koin.core.Koin
 import org.koin.core.KoinApplication
 import org.koin.core.component.KoinComponent
 import org.koin.core.parameter.parametersOf
 import org.koin.dsl.module
-import platform.Foundation.NSUserDefaults
 
 fun initKoinIos(
     appInfo: AppInfo,
@@ -26,8 +23,14 @@ fun initKoinIos(
 actual val platformModule = module {
 
     single { Darwin.create() }
+    single { DriverFactory() }
 
-    single { SelectInstitutionCallbackViewModel(get(), getWith("SelectInstitutionCallbackViewModel")) }
+    single {
+        SelectInstitutionCallbackViewModel(
+            get(),
+            getWith("SelectInstitutionCallbackViewModel")
+        )
+    }
 }
 
 // Access from Swift to create a logger

--- a/shared/core/src/iosMain/kotlin/app/eduroam/shared/storage/DriverFactory.kt
+++ b/shared/core/src/iosMain/kotlin/app/eduroam/shared/storage/DriverFactory.kt
@@ -1,0 +1,8 @@
+package app.eduroam.shared.storage
+
+import com.squareup.sqldelight.db.SqlDriver
+import com.squareup.sqldelight.drivers.native.NativeSqliteDriver
+
+actual class DriverFactory {
+    actual fun createDriver(): SqlDriver = NativeSqliteDriver(EduRoamDatabase.Schema, "eduroam.db")
+}


### PR DESCRIPTION
Added SqlDelight
We need to download and save the EAP file to local storage. The easiest way to do that with KMM seems to be SqlDelight. The entire file content is downloaded and saved in the DB as a ByteArray.
Return EAP data as a byte array from the DB or after downloading.