### PR TITLE
GETEDUROAM-57: Fix crash with TLS without client side certificate

### DIFF
--- a/android/app/src/main/java/app/eduroam/geteduroam/config/PlatformClientCertificate.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/config/PlatformClientCertificate.kt
@@ -29,9 +29,12 @@ import java.util.*
     NoSuchAlgorithmException::class,
     UnrecoverableKeyException::class
 )
-fun ClientSideCredential.getClientCertificate(
-): Map.Entry<PrivateKey, Array<X509Certificate>> {
+fun ClientSideCredential.getClientCertificate(): Map.Entry<PrivateKey, Array<X509Certificate>>? {
     try {
+        val certificateBytes = clientCertificate?.value
+        if (certificateBytes.isNullOrEmpty()) {
+            return null
+        }
         val bytes = Base64.decode(clientCertificate?.value, Base64.NO_WRAP)
         val passphraseBytes = passphrase?.toCharArray() ?: CharArray(0)
         val pkcs12ks = KeyStore.getInstance("pkcs12")

--- a/android/app/src/main/java/app/eduroam/geteduroam/config/PlatformWifiConfigData.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/config/PlatformWifiConfigData.kt
@@ -172,15 +172,17 @@ private fun EAPIdentityProviderList.handleEapTLS(enterpriseConfig: WifiEnterpris
     enterpriseConfig.phase2Method = WifiEnterpriseConfig.Phase2.NONE
     val clientCert =
         eapIdentityProvider?.authenticationMethod?.bestMethod()?.clientSideCredential?.getClientCertificate()
-    enterpriseConfig.setClientKeyEntry(
-        clientCert!!.key, clientCert.value[0]
-    )
+    if (clientCert?.key != null) {
+        enterpriseConfig.setClientKeyEntry(
+            clientCert.key, clientCert.value[0]
+        )
+    }
     // For TLS, "identity" is used for outer identity,
     // while for PEAP/TTLS, "identity" is the inner identity,
     // and anonymousIdentity is the outer identity
     // - so we have to do some weird shuffling here.
     val anonymousIdentity =
-        eapIdentityProvider.authenticationMethod?.bestMethod()?.clientSideCredential?.outerIdentity
+        eapIdentityProvider?.authenticationMethod?.bestMethod()?.clientSideCredential?.outerIdentity
     enterpriseConfig.identity = anonymousIdentity
 }
 
@@ -246,11 +248,13 @@ fun EAPIdentityProviderList.buildPasspointConfig(): PasspointConfiguration? {
             val certCred = Credential.CertificateCredential()
             val clientCert =
                     eapIdentityProvider?.authenticationMethod?.bestMethod()?.clientSideCredential?.getClientCertificate()
-            certCred.certType = "x509v3"
-            cred.clientPrivateKey = clientCert?.key!!
-            cred.clientCertificateChain = clientCert.value
-            certCred.certSha256Fingerprint = getFingerprint(clientCert.value[0])
-            cred.certCredential = certCred
+            if (clientCert?.key != null) {
+                certCred.certType = "x509v3"
+                cred.clientPrivateKey = clientCert.key
+                cred.clientCertificateChain = clientCert.value
+                certCred.certSha256Fingerprint = getFingerprint(clientCert.value[0])
+                cred.certCredential = certCred
+            }
         }
 
         Eap.PWD -> {

--- a/android/app/src/main/java/app/eduroam/geteduroam/config/model/AuthenticationMethod.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/config/model/AuthenticationMethod.kt
@@ -2,6 +2,7 @@ package app.eduroam.geteduroam.config.model
 
 import android.net.wifi.WifiEnterpriseConfig
 import app.eduroam.geteduroam.config.convertEAPMethod
+import app.eduroam.geteduroam.config.getClientCertificate
 import com.squareup.moshi.JsonClass
 import org.simpleframework.xml.Element
 import org.simpleframework.xml.Root
@@ -27,11 +28,10 @@ class AuthenticationMethod {
 fun List<AuthenticationMethod>.bestMethod(): AuthenticationMethod? {
     return firstOrNull {
         val method = it.eapMethod?.type?.toInt()?.convertEAPMethod()
-        method == WifiEnterpriseConfig.Eap.TLS
-    } ?:
-    firstOrNull {
-        val method = it.eapMethod?.type?.toInt()?.convertEAPMethod()
-        method == WifiEnterpriseConfig.Eap.PEAP || method == WifiEnterpriseConfig.Eap.TTLS|| method == WifiEnterpriseConfig.Eap.PWD
+        method == WifiEnterpriseConfig.Eap.PEAP ||
+                method == WifiEnterpriseConfig.Eap.TTLS ||
+                method == WifiEnterpriseConfig.Eap.PWD ||
+                (method == WifiEnterpriseConfig.Eap.TLS && it.clientSideCredential?.getClientCertificate()!= null)
     } ?:
     firstOrNull()
 }


### PR DESCRIPTION
Also changed the default order of authentication methods to prefer the order set in the CMS more