### PR TITLE
GETEDUROAM-55: Open .eap-config files

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -29,6 +29,28 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
+            <!-- MIME Type registration -->
+            <intent-filter>
+                <data
+                    android:mimeType="application/eap-config"
+                    android:pathPattern=".*\\.eap-config"
+                    android:scheme="content" />
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+            </intent-filter>
+            <intent-filter>
+                <data
+                    android:mimeType="application/octet-stream"
+                    android:pathPattern=".*\\.eap-config"
+                    android:scheme="content" />
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+            </intent-filter>
+
         </activity>
 
         <activity
@@ -48,7 +70,7 @@
 
         <receiver
             android:name=".di.repository.NotificationAlarmReceiver"
-            android:exported="false"/>
+            android:exported="false" />
 
     </application>
 

--- a/android/app/src/main/java/app/eduroam/geteduroam/MainActivity.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/MainActivity.kt
@@ -1,6 +1,7 @@
 package app.eduroam.geteduroam
 
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.webkit.WebView
 import androidx.activity.ComponentActivity
@@ -9,14 +10,26 @@ import androidx.core.view.WindowCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.findNavController
+import app.eduroam.geteduroam.config.WifiConfigScreen
 import app.eduroam.geteduroam.di.repository.NotificationRepository
 import app.eduroam.geteduroam.ui.theme.AppTheme
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.job
+import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
     private var navController: NavController? = null
+
+    private val job = Job()
+    val coroutineContext: CoroutineContext
+        get() = job + Dispatchers.IO
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -32,15 +45,31 @@ class MainActivity : ComponentActivity() {
                     })
             }
         }
-        runOnUiThread {
-            navController?.handleDeepLink(intent)
-        }
+        handleNewIntent(intent)
     }
 
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
+        handleNewIntent(intent)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        job.cancel()
+    }
+
+    private fun handleNewIntent(intent: Intent?) {
         runOnUiThread {
-            navController?.handleDeepLink(intent)
+            if (intent?.dataString?.startsWith("content://") == true) {
+                CoroutineScope(coroutineContext).launch {
+                    Route.ConfigureWifi.buildDeepLink(this@MainActivity, intent.data!!)?.let {
+                        intent.data = Uri.parse(it)
+                        navController?.handleDeepLink(intent)
+                    }
+                }
+            } else {
+                navController?.handleDeepLink(intent)
+            }
         }
     }
 }

--- a/android/app/src/main/java/app/eduroam/geteduroam/MainActivity.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/MainActivity.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
 @AndroidEntryPoint
@@ -64,7 +65,9 @@ class MainActivity : ComponentActivity() {
                 CoroutineScope(coroutineContext).launch {
                     Route.ConfigureWifi.buildDeepLink(this@MainActivity, intent.data!!)?.let {
                         intent.data = Uri.parse(it)
-                        navController?.handleDeepLink(intent)
+                        withContext(Dispatchers.Main) {
+                            navController?.handleDeepLink(intent)
+                        }
                     }
                 }
             } else {

--- a/android/app/src/main/java/app/eduroam/geteduroam/MainGraph.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/MainGraph.kt
@@ -97,7 +97,7 @@ fun MainGraph(
                 viewModel,
                 closeApp = closeApp,
                 goBack = {
-                    navController.popBackStack()
+                    navController.navigateUp()
                 }
             )
         }

--- a/android/app/src/main/java/app/eduroam/geteduroam/MainGraph.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/MainGraph.kt
@@ -85,14 +85,20 @@ fun MainGraph(
             })
         }
         composable(
-            route = Route.ConfigureWifi.routeWithArgs, arguments = Route.ConfigureWifi.arguments
+            route = Route.ConfigureWifi.routeWithArgs, arguments = Route.ConfigureWifi.arguments,
+            deepLinks = listOf(navDeepLink {
+                uriPattern = Route.ConfigureWifi.deepLinkUrl
+            })
         ) { backStackEntry ->
             val wifiConfigData = Route.ConfigureWifi.decodeUrlArgument(backStackEntry.arguments)
             val viewModel = hiltViewModel<WifiConfigViewModel>()
             viewModel.eapIdentityProviderList = wifiConfigData
             WifiConfigScreen(
                 viewModel,
-                closeApp = closeApp
+                closeApp = closeApp,
+                goBack = {
+                    navController.popBackStack()
+                }
             )
         }
     }

--- a/android/app/src/main/java/app/eduroam/geteduroam/config/PlatformWifiConfigData.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/config/PlatformWifiConfigData.kt
@@ -137,6 +137,10 @@ fun EAPIdentityProvider.requiresUsernamePrompt(): Boolean {
     return  eapMethod == Eap.TTLS || eapMethod == Eap.PEAP
 }
 
+fun EAPIdentityProvider.requiredSuffix(): String? {
+    return authenticationMethod?.bestMethod()?.clientSideCredential?.innerIdentitySuffix
+}
+
 /**
  * Converts an internal EAP method type to the one used by Android
  */

--- a/android/app/src/main/java/app/eduroam/geteduroam/extensions/InputStream.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/extensions/InputStream.kt
@@ -1,0 +1,21 @@
+package app.eduroam.geteduroam.extensions
+
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.InputStream
+
+@Throws(IOException::class)
+fun InputStream.readBytes(): ByteArray {
+    val bufLen = 4 * 0x400 // 4KB
+    val buf = ByteArray(bufLen)
+    var readLen: Int = 0
+
+    ByteArrayOutputStream().use { o ->
+        this.use { i ->
+            while (i.read(buf, 0, bufLen).also { readLen = it } != -1)
+                o.write(buf, 0, readLen)
+        }
+
+        return o.toByteArray()
+    }
+}

--- a/android/app/src/main/java/app/eduroam/geteduroam/organizations/OrganizationRow.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/organizations/OrganizationRow.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -46,7 +47,7 @@ fun OrganizationRow(
             color = MaterialTheme.colorScheme.secondary
         )
         Spacer(Modifier.height(8.dp))
-        Divider(
+        HorizontalDivider(
             Modifier
                 .height(0.5.dp)
                 .fillMaxWidth(),

--- a/android/app/src/main/java/app/eduroam/geteduroam/profile/SelectProfileScreen.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/profile/SelectProfileScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Check
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -96,6 +97,7 @@ fun SelectProfileScreen(
             .filter { it.goToConfigScreenWithProviderList != null }.flowWithLifecycle(lifecycle).collect { state ->
                 val providerList = state.goToConfigScreenWithProviderList!!
                 goToConfigScreen(providerList)
+                viewModel.didGoToConfigScreen()
             }
     }
 
@@ -128,16 +130,6 @@ fun SelectProfileScreen(
             }, onDismiss = {
                 viewModel.didAgreeToTerms(false)
             }
-        )
-    }
-    if (viewModel.uiState.showUsernameDialog) {
-        UsernamePasswordDialog(
-            requiredSuffix = viewModel.uiState.organization?.requiredSuffix,
-            cancel = viewModel::didCancelLogin, // Just hide the dialog
-            logIn = { username, password ->
-                viewModel.didEnterLoginDetails(username = username, password = password)
-            }
-
         )
     }
 }
@@ -201,17 +193,14 @@ fun SelectProfileContent(
                 modifier = Modifier.fillMaxWidth()
             )
             Spacer(Modifier.height(4.dp))
-            Divider(
+            HorizontalDivider(
                 modifier = Modifier.fillMaxWidth(),
                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
             )
-            Spacer(Modifier.height(4.dp))
-
             if (inProgress) {
-                Spacer(Modifier.height(4.dp))
                 LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
-                Spacer(Modifier.height(4.dp))
             }
+            Spacer(Modifier.height(4.dp))
             profiles.forEach { profile ->
                 Row(
                     modifier = Modifier
@@ -234,7 +223,7 @@ fun SelectProfileContent(
                         )
                     }
                 }
-                Divider(
+                HorizontalDivider(
                     modifier = Modifier.fillMaxWidth(),
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
                 )

--- a/android/app/src/main/java/app/eduroam/geteduroam/profile/SelectProfileViewModel.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/profile/SelectProfileViewModel.kt
@@ -220,15 +220,12 @@ class SelectProfileViewModel @Inject constructor(
                     description = info?.description,
                     logo = info?.providerLogo?.value,
                     termsOfUse = info?.termsOfUse,
-                    helpDesk = info?.helpdesk,
-                    requiredSuffix = firstProvider.authenticationMethod?.bestMethod()?.clientSideCredential?.innerIdentitySuffix
+                    helpDesk = info?.helpdesk
                 ),
                 providerInfo = info
             )
             if (info?.termsOfUse != null && !didAgreeToTerms) {
                 uiState = uiState.copy(inProgress = false, showTermsOfUseDialog = true)
-            } else if (firstProvider.requiresUsernamePrompt()) {
-                uiState = uiState.copy(inProgress = false, showUsernameDialog = true, credentialsEnteredForProviderList = providers)
             } else {
                 uiState = uiState.copy(inProgress = false, goToConfigScreenWithProviderList = providers)
             }
@@ -259,24 +256,6 @@ class SelectProfileViewModel @Inject constructor(
         uiState = uiState.copy(errorData = null)
     }
 
-    fun didCancelLogin() {
-        uiState = uiState.copy(showUsernameDialog = false)
-    }
-
-    fun didEnterLoginDetails(username: String, password: String) {
-        val profileList = uiState.credentialsEnteredForProviderList ?: throw RuntimeException("Profile list not found for entered credentials!")
-        profileList.eapIdentityProvider?.forEach { idp ->
-            idp.authenticationMethod?.forEach { authMethod ->
-                authMethod.clientSideCredential?.apply {
-                    this.userName = username
-                    this.password = password
-                }
-            }
-        }
-        uiState = uiState.copy(credentialsEnteredForProviderList = null, goToConfigScreenWithProviderList = profileList)
-
-    }
-
     /**
      * Call this when you start the OAuth flow, to avoid recalling it each time the screen is composed, and also to trigger the next check
      */
@@ -301,5 +280,9 @@ class SelectProfileViewModel @Inject constructor(
             uiState = uiState.copy(checkProfileWhenResuming = false)
             connectWithProfile(profile.profile, startOAuthFlowIfNoAccess = false)
         }
+    }
+
+    fun didGoToConfigScreen() {
+        uiState = uiState.copy(goToConfigScreenWithProviderList = null)
     }
 }

--- a/android/app/src/main/java/app/eduroam/geteduroam/profile/UiState.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/profile/UiState.kt
@@ -9,7 +9,6 @@ import app.eduroam.geteduroam.ui.ErrorData
 
 data class UiState(
     val profiles: List<PresentProfile> = emptyList(),
-    val credentialsEnteredForProviderList: EAPIdentityProviderList? = null,
     val organization: PresentOrganization? = null,
     val providerInfo: ProviderInfo? = null,
     val inProgress: Boolean = false,
@@ -17,7 +16,6 @@ data class UiState(
     val promptForOAuth: Boolean = false,
     val checkProfileWhenResuming: Boolean = false,
     val showTermsOfUseDialog: Boolean = false,
-    val showUsernameDialog: Boolean = false,
     val goToConfigScreenWithProviderList: EAPIdentityProviderList? = null,
     val openUrlInBrowser: String? = null
 )
@@ -31,6 +29,5 @@ data class PresentOrganization(
     val description: String? = null,
     val logo: String? = null,
     val termsOfUse: String? = null,
-    val helpDesk: Helpdesk? = null,
-    val requiredSuffix: String? = null
+    val helpDesk: Helpdesk? = null
 )

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="profiles_title">Profiles</string>
     <string name="profiles_header">Select a profile</string>
     <string name="configuration_progress">Establishing WiFi connection</string>
+    <string name="configuration_waiting_for_user_credentials">Waiting for user credentials…</string>
     <string name="configuration_success">WiFi configured</string>
     <string name="configuration_logs">Log messages:</string>
     <string name="configuration_canceled">Canceled</string>


### PR DESCRIPTION
Adds the ability to open .eap-config files from the phone's storage.

This also means that I had to move the username-password prompt to the config screen, because in this case there's no profile to select, but we still need the user credentials.