### PR TITLE
Update intent-filter for sideloading eap-config

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -33,7 +33,6 @@
             <intent-filter>
                 <data
                     android:mimeType="application/eap-config"
-                    android:pathPattern=".*\\.eap-config"
                     android:scheme="content" />
                 <action android:name="android.intent.action.VIEW" />
 
@@ -42,7 +41,15 @@
             </intent-filter>
             <intent-filter>
                 <data
-                    android:mimeType="application/octet-stream"
+                    android:mimeType="application/x-eap-config"
+                    android:scheme="content" />
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+            </intent-filter>
+            <intent-filter>
+                <data
                     android:pathPattern=".*\\.eap-config"
                     android:scheme="content" />
                 <action android:name="android.intent.action.VIEW" />


### PR DESCRIPTION
* Add support for application/x-eap-config content-type
* Do not trigger on application/octet-stream
* Don't require content-type if file extension matches
* Don't require file extension if content-type matches

Please be aware that I DID NOT TEST these changes.
