### PR TITLE
Fix app not being able to open some eap-config files

### DIFF
--- a/android/app/src/main/java/app/eduroam/geteduroam/config/model/EAPIdentityProvider.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/config/model/EAPIdentityProvider.kt
@@ -32,6 +32,6 @@ data class EAPIdentityProvider(
     @field:Attribute
     var version: Int? = null,
 
-    @field:Attribute
+    @field:Attribute(required = false)
     var lang: String? = null,
 )


### PR DESCRIPTION
Fixes #74 

The `lang` property was missing on the identity provider.
Since we do not make use of it inside the app, I have marked it non-required.
Sadly our XML parser is very strict by default, so this can happen with some irregular config files