### PR TITLE
#76 Handle server names being too long, change cert filter

### DIFF
--- a/android/app/src/main/java/app/eduroam/geteduroam/config/CertificateUtilities.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/config/CertificateUtilities.kt
@@ -25,7 +25,7 @@ fun isRootCertificate(certificate: X509Certificate): Boolean =
  * @param certificate The certificate to check
  * @return The certificate is a CA certificate
  */
-private fun isCA(certificate: X509Certificate): Boolean {
+fun isCA(certificate: X509Certificate): Boolean {
 
     val usage = certificate.keyUsage
 

--- a/android/app/src/main/java/app/eduroam/geteduroam/config/PlatformWifiConfigData.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/config/PlatformWifiConfigData.kt
@@ -110,7 +110,7 @@ private fun EAPIdentityProviderList.buildEnterpriseConfig(): WifiEnterpriseConfi
 
     val caCertificates = authMethod?.serverSideCredential?.certData?.mapNotNull { it.value }
     enterpriseConfig.caCertificates = getCertificates(caCertificates)
-        .filter { isRootCertificate(it) }
+        .filter { isCA(it) }
         .toTypedArray()
 
     val serverNames = authMethod?.serverSideCredential?.serverId

--- a/android/app/src/main/java/app/eduroam/geteduroam/config/PlatformWifiConfigData.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/config/PlatformWifiConfigData.kt
@@ -210,8 +210,9 @@ private fun EAPIdentityProviderList.handleEapTLS(enterpriseConfig: WifiEnterpris
 private fun EAPIdentityProviderList.getServerNamesDomainDependentOnAndroidVersion(): String? {
     val eapIdentityProvider = eapIdentityProvider?.first()
     val serverNames = eapIdentityProvider?.authenticationMethod?.bestMethod()?.serverSideCredential?.serverId ?: emptyList()
-    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-        serverNames.joinToString(";")
+    val joinedServerNames = serverNames.joinToString(";")
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && joinedServerNames.length < 256) {
+        joinedServerNames
     } else {
         getLongestSuffix(serverNames)
     }


### PR DESCRIPTION
It turns out that some of the institutions use a pretty long list of server names, and when joined together, it was longer than 256 characters, which the Enterprise config did not like, and it just reset that field to an empty string, which then made the validity check fail. So we fall back to the old behavior, if we detect that the joined list is too long.