### PR TITLE
GETEDUROAM-70: WebView fallback, when there is no browser to handle auth

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -68,6 +68,13 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name=".webview_fallback.WebViewDataHandlingActivity"
+            android:exported="false"
+            android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation|keyboard|keyboardHidden"
+            android:launchMode="singleTask"
+            android:theme="@style/Theme.AppCompat.Translucent.NoTitleBar"/>
+
         <receiver
             android:name=".di.repository.NotificationAlarmReceiver"
             android:exported="false" />

--- a/android/app/src/main/java/app/eduroam/geteduroam/oauth/OAuthStep.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/oauth/OAuthStep.kt
@@ -1,7 +1,10 @@
 package app.eduroam.geteduroam.oauth
 
 import android.content.Intent
+import android.net.Uri
+import app.eduroam.geteduroam.models.Configuration
 import app.eduroam.geteduroam.ui.ErrorData
+import net.openid.appauth.AuthorizationRequest
 
 /**
  * Loading
@@ -12,7 +15,9 @@ import app.eduroam.geteduroam.ui.ErrorData
  * */
 sealed class OAuthStep {
     object Loading : OAuthStep()
-    class Initialized(val intent: Intent) : OAuthStep()
+    data class Initialized(val intent: Intent) : OAuthStep()
+    data class WebViewFallback(val configuration: Configuration, val requestUri: Uri): OAuthStep()
+    data class GetTokensFromRedirectUri(val redirectUri: Uri, val authRequest: AuthorizationRequest): OAuthStep()
     object Launched : OAuthStep()
     object ExchangingTokenRequest : OAuthStep()
     object Authorized : OAuthStep()

--- a/android/app/src/main/java/app/eduroam/geteduroam/ui/WebViewComposable.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/ui/WebViewComposable.kt
@@ -1,0 +1,51 @@
+package app.eduroam.geteduroam.ui
+
+import android.net.Uri
+import android.view.ViewGroup
+import android.view.ViewGroup.MarginLayoutParams
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.viewinterop.AndroidView
+import app.eduroam.geteduroam.BuildConfig
+import timber.log.Timber
+
+@Composable
+fun OAuthWebView(startUrl: Uri, onRedirectUriFound: (Uri) -> Unit) {
+    // Adding a WebView inside AndroidView
+    // with layout as full screen
+    AndroidView(factory = {
+        WebView(it).apply {
+            settings.javaScriptEnabled = true
+            settings.domStorageEnabled = true
+            this.layoutParams = ViewGroup.MarginLayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+            this.webViewClient = RedirectUriInterceptingWebViewClient(onRedirectUriFound)
+        }
+    }, update = {
+        it.loadUrl(startUrl.toString())
+    })
+}
+
+class RedirectUriInterceptingWebViewClient(private val onRedirectUriFound: (Uri) -> Unit) : WebViewClient() {
+
+    private val redirectScheme = Uri.parse(BuildConfig.OAUTH_REDIRECT_URI).scheme
+
+    override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
+        try {
+            val uri = request?.url
+            if (uri != null && uri.scheme == redirectScheme) {
+                onRedirectUriFound(uri)
+                return true
+            }
+        } catch (ex: Exception) {
+            Timber.i("Could not parse navigation URI!", ex)
+        }
+        return false
+    }
+}

--- a/android/app/src/main/java/app/eduroam/geteduroam/webview_fallback/WebViewDataHandlingActivity.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/webview_fallback/WebViewDataHandlingActivity.kt
@@ -1,0 +1,37 @@
+package app.eduroam.geteduroam.webview_fallback
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import app.eduroam.geteduroam.MainActivity
+import net.openid.appauth.AuthorizationManagementActivity
+import net.openid.appauth.AuthorizationRequest
+
+/**
+ * With this activity we trick the AppAuth library into believing it is being redirected from its own flow while we did the flow ourselves in a WebView
+ */
+class WebViewDataHandlingActivity: AuthorizationManagementActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        savedInstanceState?.putAll(intent.extras)
+        super.onCreate(savedInstanceState)
+    }
+
+    companion object {
+
+        fun createIntent(context: Context, authorizationRequest: AuthorizationRequest, redirectUri: Uri): Intent {
+            val resultIntent = createStartIntent(
+                context,
+                authorizationRequest,
+                Intent(),
+                null,
+                null
+            )
+            resultIntent.setClass(context, WebViewDataHandlingActivity::class.java)
+            resultIntent.putExtra("authStarted", true)
+            resultIntent.data = redirectUri
+            return resultIntent
+        }
+    }
+}

--- a/android/app/src/main/java/app/eduroam/geteduroam/webview_fallback/WebViewFallbackScreen.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/webview_fallback/WebViewFallbackScreen.kt
@@ -1,0 +1,77 @@
+package app.eduroam.geteduroam.webview_fallback
+
+import android.app.PendingIntent
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.lifecycle.flowWithLifecycle
+import app.eduroam.geteduroam.EduTopAppBar
+import app.eduroam.geteduroam.R
+import app.eduroam.geteduroam.models.Configuration
+import app.eduroam.geteduroam.ui.OAuthWebView
+import kotlinx.coroutines.flow.filter
+import net.openid.appauth.AuthorizationManagementActivity
+import net.openid.appauth.RedirectUriReceiverActivity
+
+@Composable
+fun WebViewFallbackScreen(
+    viewModel: WebViewFallbackViewModel,
+    onRedirectUriFound: (Configuration, Uri) -> Unit,
+    onCancel: () -> Unit
+) = EduTopAppBar(onBackClicked = onCancel, title = stringResource(id = R.string.oauth_title)) {
+
+    val lifecycle = LocalLifecycleOwner.current.lifecycle
+
+    LaunchedEffect(viewModel, lifecycle) {
+        snapshotFlow { viewModel.uiState }
+            .filter { it.didNavigateToRedirectUri != null }
+            .flowWithLifecycle(lifecycle)
+            .collect { state ->
+                val navigatedUri = state.didNavigateToRedirectUri!!
+                onRedirectUriFound(viewModel.configuration, navigatedUri)
+            }
+    }
+
+
+    WebViewFallbackContent(
+        uiState = viewModel.uiState,
+        padding = it,
+        onRedirectUriFound = {
+            viewModel.uiState = viewModel.uiState.copy(didNavigateToRedirectUri = it)
+        })
+}
+
+@Composable
+private fun WebViewFallbackContent(
+    uiState: UiState,
+    padding: PaddingValues,
+    onRedirectUriFound: (Uri) -> Unit
+) {
+
+    Box(modifier = Modifier.padding(padding)) {
+        OAuthWebView(
+            startUrl = uiState.startUri,
+            onRedirectUriFound = onRedirectUriFound
+        )
+    }
+}
+
+@Preview
+@Composable
+fun PreviewWebviewFallbackContent() = WebViewFallbackContent(UiState(), PaddingValues(), onRedirectUriFound = {})

--- a/android/app/src/main/java/app/eduroam/geteduroam/webview_fallback/WebViewFallbackViewModel.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/webview_fallback/WebViewFallbackViewModel.kt
@@ -1,0 +1,42 @@
+package app.eduroam.geteduroam.webview_fallback
+
+import android.net.Uri
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import app.eduroam.geteduroam.Route
+import app.eduroam.geteduroam.di.api.GetEduroamApi
+import app.eduroam.geteduroam.di.repository.StorageRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import net.openid.appauth.AuthorizationRequest
+import javax.inject.Inject
+
+@HiltViewModel
+class WebViewFallbackViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val repository: StorageRepository,
+    val api: GetEduroamApi,
+): ViewModel() {
+
+    var uiState by mutableStateOf(UiState())
+
+    val configuration = Route.WebViewFallback.decodeConfigurationArgument(savedStateHandle.get(Route.WebViewFallback.configurationArg) ?: "")
+    init {
+        val requestUriArg = savedStateHandle.get<String>(Route.WebViewFallback.urlArg)!!
+        uiState = UiState(startUri =  Uri.parse(requestUriArg))
+    }
+
+    fun getAuthRequest(): Flow<AuthorizationRequest?> {
+        return repository.authRequest
+    }
+}
+
+data class UiState(
+    val startUri: Uri = Uri.EMPTY,
+    val didNavigateToRedirectUri: Uri? = null
+)

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -30,6 +30,8 @@
     <string name="err_title_auth_unexpected_fail">Unexpected error</string>
     <string name="err_msg_auth_init_fail">Failed to initialize AppData. Please retry.</string>
     <string name="err_msg_auth_init_fail_arg">Failed to initialize AppData. Reason: %s</string>
+    <string name="err_msg_auth_no_saved_configuration">Saved configuration not found</string>
+    <string name="err_msg_auth_no_matching_auth_request">No authorization request for redirect URI found</string>
     <string name="err_title_auth_invalid">Authorization invalid</string>
     <string name="err_msg_auth_invalid">Did not receive valid authentication.</string>
     <string name="err_title_auth_failed">Authorization failed</string>


### PR DESCRIPTION
We had some cases where users had no browser to handle the auth request. One example was a device without Chrome, but with Edge installed. With this PR we add an extra screen, which is a fallback to a WebView. Here we detect the redirect, and trigger the same AppAuth flow, so there's no need to write the same code for comparing states, validating and parsing OAuth responses.
