### PR TITLE
GETEDUROAM-54: Fix crash on release build, improve screen transition

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -11,3 +11,6 @@
 }
 -keepattributes Signature
 -keepattributes ElementList, Root, *Annotation*
+# Required by safe navigation types (otherwise it will throw IllegalArgumentException's when building the graph)
+-keepnames class * extends android.os.Parcelable
+-keepnames class * extends java.io.Serializable

--- a/android/app/src/main/java/app/eduroam/geteduroam/status/StatusScreen.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/status/StatusScreen.kt
@@ -74,7 +74,6 @@ fun StatusScreen(
             goToInstitutionSelection()
         }
     }
-
     Column(
         modifier = Modifier
             .fillMaxSize(),
@@ -155,6 +154,12 @@ fun StatusScreenContent(
             )
         }
     }
+
+    if (organizationId.isNullOrEmpty()) {
+        // Do not draw any actual content yet while we are waiting for the value
+        return@Surface
+    }
+
     // OAuth logins expire after a specific time, regular logins do not, we show different texts for these two
     Column(
         modifier = Modifier


### PR DESCRIPTION
* This PR fixes a crash which happened on release builds due to a misconfiguration in Proguard
* I also improved the first install transition, the status screen should not show up anymore briefly before going to the institution search screen