### PR TITLE
GETEDUROAM-0: Fix default values in lets wifi config

### DIFF
--- a/android/app/src/main/java/app/eduroam/geteduroam/models/LetswifiConfig.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/models/LetswifiConfig.kt
@@ -9,11 +9,11 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class LetswifiConfig(
     @SerialName("eapconfig_endpoint")
-    val eapConfigEndpoint: String?,
+    val eapConfigEndpoint: String? = null,
     @SerialName("mobileconfig_endpoint")
-    val mobileConfigEndpoint: String?,
+    val mobileConfigEndpoint: String? = null,
     @SerialName("authorization_endpoint")
-    val authorizationEndpoint: String?,
+    val authorizationEndpoint: String? = null,
     @SerialName("token_endpoint")
-    val tokenEndpoint: String?
+    val tokenEndpoint: String? = null
 ) : Parcelable


### PR DESCRIPTION
Profile fetching of some organizations failed because of this