### PR TITLE
Issue #140: Parse multilingual configs

### DIFF
--- a/android/app/src/main/java/app/eduroam/geteduroam/config/model/ProviderInfo.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/config/model/ProviderInfo.kt
@@ -1,18 +1,21 @@
 package app.eduroam.geteduroam.config.model
 
 import kotlinx.serialization.Serializable
+import org.simpleframework.xml.Attribute
 import org.simpleframework.xml.Element
 import org.simpleframework.xml.ElementList
 import org.simpleframework.xml.Root
+import org.simpleframework.xml.Text
+import java.util.Locale
 
 @Root(name = "ProviderInfo")
 @Serializable
 data class ProviderInfo(
-    @field:Element(name = "DisplayName", required = false)
-    var displayName: String? = null,
+    @field:ElementList(inline = true, entry = "DisplayName", required = false)
+    var displayNames: List<LocalizedText>? = null,
 
-    @field:Element(name = "Description", required = false)
-    var description: String? = null,
+    @field:ElementList(inline = true, entry = "Description", required = false)
+    var descriptions: List<LocalizedText>? = null,
 
     @field:ElementList(inline = true, entry = "ProviderLocation", required = false)
     var providerLocations: List<ProviderLocation>? = null,
@@ -20,9 +23,32 @@ data class ProviderInfo(
     @field:Element(name = "ProviderLogo", required = false)
     var providerLogo: ProviderLogo? = null,
 
-    @field:Element(name = "TermsOfUse", required = false)
-    var termsOfUse: String? = null,
+    @field:ElementList(inline = true, entry = "TermsOfUse", required = false)
+    var termsOfUse: List<LocalizedText>? = null,
 
     @field:Element(name = "Helpdesk", required = false)
     var helpdesk: Helpdesk? = null
 )
+
+
+@Serializable
+data class LocalizedText(
+    // The 'lang' attribute of the XML tag
+    @field:Attribute(name = "lang", required = false)
+    var lang: String? = null,
+
+    // The text content of the XML tag
+    @field:Text
+    var value: String = ""
+)
+
+fun List<LocalizedText>.localizedMatch(): String? {
+    val language = Locale.getDefault().language.lowercase()
+    // Find the first match for the specified language
+    val match = this.firstOrNull { it.lang.equals(language, ignoreCase = true) }
+    if (match != null) {
+        return match.value
+    }
+    // If no match is found, return the first available value
+    return this.firstOrNull()?.value
+}

--- a/android/app/src/main/java/app/eduroam/geteduroam/organizations/TermsOfUseDialog.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/organizations/TermsOfUseDialog.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import app.eduroam.geteduroam.R
 import app.eduroam.geteduroam.config.model.ProviderInfo
+import app.eduroam.geteduroam.config.model.localizedMatch
 import app.eduroam.geteduroam.extensions.removeNonSpacingMarks
 import app.eduroam.geteduroam.ui.LinkifyText
 
@@ -52,7 +53,7 @@ fun TermsOfUseDialog(
             )
             Spacer(modifier = Modifier.size(16.dp))
             var dialogDescription = stringResource(R.string.terms_of_use_dialog_text)
-            providerInfo?.termsOfUse?.let { termsOfUse ->
+            providerInfo?.termsOfUse?.localizedMatch()?.let { termsOfUse ->
                 dialogDescription += "\n\n" + termsOfUse.trim()
             }
             val topScrimAmount = 24.dp

--- a/android/app/src/main/java/app/eduroam/geteduroam/profile/SelectProfileScreen.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/profile/SelectProfileScreen.kt
@@ -56,6 +56,7 @@ import app.eduroam.geteduroam.EduTopAppBar
 import app.eduroam.geteduroam.R
 import app.eduroam.geteduroam.config.model.EAPIdentityProviderList
 import app.eduroam.geteduroam.config.model.ProviderInfo
+import app.eduroam.geteduroam.config.model.localizedMatch
 import app.eduroam.geteduroam.models.Configuration
 import app.eduroam.geteduroam.organizations.TermsOfUseDialog
 import app.eduroam.geteduroam.models.Profile
@@ -296,7 +297,7 @@ fun SelectProfileContent(
                         Column(
                             modifier = Modifier.fillMaxWidth(fraction = 1f)
                         ) {
-                            providerInfo.displayName?.let { displayName ->
+                            providerInfo.displayNames?.localizedMatch()?.let { displayName ->
                                 Text(
                                     text = displayName,
                                     style = MaterialTheme.typography.titleSmall,
@@ -325,7 +326,7 @@ fun SelectProfileContent(
                                     Spacer(modifier = Modifier.size(4.dp))
                                 }
                             }
-                            providerInfo.termsOfUse?.let { termsOfUse ->
+                            providerInfo.termsOfUse?.localizedMatch()?.let { termsOfUse ->
                                 Text(
                                     text = stringResource(id = R.string.terms_of_use_dialog_title),
                                     style = MaterialTheme.typography.titleSmall,

--- a/android/app/src/main/java/app/eduroam/geteduroam/profile/SelectProfileViewModel.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/profile/SelectProfileViewModel.kt
@@ -15,6 +15,7 @@ import app.eduroam.geteduroam.R
 import app.eduroam.geteduroam.Route
 import app.eduroam.geteduroam.config.AndroidConfigParser
 import app.eduroam.geteduroam.config.model.EAPIdentityProviderList
+import app.eduroam.geteduroam.config.model.localizedMatch
 import app.eduroam.geteduroam.di.api.GetEduroamApi
 import app.eduroam.geteduroam.di.repository.StorageRepository
 import app.eduroam.geteduroam.models.DiscoveryResult
@@ -135,7 +136,7 @@ class SelectProfileViewModel @Inject constructor(
                     }
                     result
                 }
-                val autoConnectWithSingleProfile = isSingleProfile && !presentProfiles[0].isConfigured
+                val autoConnectWithSingleProfile = isSingleProfile && !presentProfiles[0].isConfigured && uiState.configuredOrganization == null
                 uiState = uiState.copy(
                     inProgress = autoConnectWithSingleProfile,
                     profiles = presentProfiles,
@@ -334,10 +335,10 @@ class SelectProfileViewModel @Inject constructor(
                 organization = PresentOrganization(
                     name = knownInstitution?.name,
                     location = knownInstitution?.location,
-                    displayName = info?.displayName,
-                    description = info?.description,
+                    displayName = info?.displayNames?.localizedMatch(),
+                    description = info?.descriptions?.localizedMatch(),
                     logo = info?.providerLogo?.value,
-                    termsOfUse = info?.termsOfUse,
+                    termsOfUse = info?.termsOfUse?.localizedMatch(),
                     helpDesk = info?.helpdesk
                 ),
                 providerInfo = info


### PR DESCRIPTION
We now parse the name, description and terms of use as a list, and try to match it to the language the user has set.
If no match found, we display the first entry in the list.

Fixes #140 