### PR TITLE
Correct improper string argument in NL localisation

### DIFF
--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -8,7 +8,7 @@
     <string name="profiles_title">Profielen</string>
     <string name="profiles_header">Kies een profiel</string>
     <string name="profiles_already_configured_for_profile">Reeds ingesteld voor %s-profiel</string>
-    <string name="profiles_do_you_want_to_reconfigure_device">Wil je jouw toestel instellen om het %@-profiel te gebruiken?</string>
+    <string name="profiles_do_you_want_to_reconfigure_device">Wil je jouw toestel instellen om het %s-profiel te gebruiken?</string>
     <string name="profiles_connected_with_profile">Reeds verbonden</string>
     <string name="profiles_reconfigure_device_to_renew">Stel jouw toestel opnieuw in om netwerktoegang te vernieuwen of als je problemen ervaart met het netwerk.</string>
     <string name="profiles_reconfigure_profile">Stel toestel opnieuw in</string>


### PR DESCRIPTION
Fixes an improper string argument in the Dutch localisation causing a crash when trying to reconfigure device. Other localisations are unaffected.

Old:
[Screen_recording_20251107_113829.webm](https://github.com/user-attachments/assets/069dd323-3873-4c4f-a243-7c4743a4f2b8)


New: 
[Screen_recording_20251107_113914.webm](https://github.com/user-attachments/assets/d321d0cb-1aa8-4ea3-a8d9-4c5f4eac612e)
