### PR TITLE
Make sure normalization is applied to all search terms to avoid incoherent behavior

### DIFF
--- a/android/app/src/main/java/app/eduroam/geteduroam/organizations/SelectOrganizationViewModel.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/organizations/SelectOrganizationViewModel.kt
@@ -109,7 +109,7 @@ class SelectOrganizationViewModel @Inject constructor(
     fun onSearchTextChange(filter: String) {
         val filtered = if (filter.isNotBlank()) {
             val normalizedFilter = filter.removeNonSpacingMarks()
-            val filterWords = filter.split(" ")
+            val filterWords = normalizedFilter.split(" ")
             allOrganizations.filter { organization ->
                 if (filterWords.size == 1) {
                     organization.matchWords.any {


### PR DESCRIPTION
Fixes issues where the search results would differ when searching for multiple words due to normalization only being applied on the first word. 