### PR TITLE
Do not prompt username/password if already provided

### DIFF
--- a/android/app/src/main/java/app/eduroam/geteduroam/config/PlatformWifiConfigData.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/config/PlatformWifiConfigData.kt
@@ -136,8 +136,13 @@ private fun EAPIdentityProviderList.buildEnterpriseConfig(): WifiEnterpriseConfi
 }
 
 fun EAPIdentityProvider.requiresUsernamePrompt(): Boolean {
-    val eapMethod = authenticationMethod?.bestMethod()?.eapMethod?.type?.toInt()?.convertEAPMethod()
-    return  eapMethod == Eap.TTLS || eapMethod == Eap.PEAP || eapMethod == Eap.PWD
+	val authMethod = authenticationMethod?.bestMethod() ?: return false
+	val credential = authMethod.clientSideCredential
+	return when(authMethod.eapMethod?.type?.toInt()?.convertEAPMethod()) {
+		Eap.TTLS,Eap.PEAP,Eap.PWD -> "" == credential?.userName ?: "" &&
+			"" == credential?.password ?: ""
+		else -> false
+	}
 }
 
 fun EAPIdentityProvider.requiredSuffix(): String? {


### PR DESCRIPTION
If a username/password combination is already provided in the ClientSideCredential, do not prompt for a username/password.

	<ClientSideCredential>
		<UserName>user@example.com</UserName>
		<Password>Tr0b4d0r</Password>
	</ClientSideCredential>